### PR TITLE
Allow passing extra browserOptions to Sentry tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/frontend-helpers",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "A library of functions commonly used across many Stellar frontend projects",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/helpers/errorReporting/index.ts
+++ b/src/helpers/errorReporting/index.ts
@@ -14,12 +14,14 @@ interface ReportErrors {
   projectName: string;
   releaseVersion?: string;
   tracingOrigins?: Array<string | RegExp>;
+  extra?: Sentry.BrowserOptions;
 }
 
 const reportErrors = ({
   projectName,
   releaseVersion,
   tracingOrigins,
+  extra,
 }: ReportErrors) => {
   if (window._env_.SENTRY_API_KEY) {
     Sentry.init({
@@ -35,6 +37,7 @@ const reportErrors = ({
           : new Integrations.BrowserTracing(),
       ],
       tracesSampleRate: 1.0,
+      ...(extra ? extra : {}),
     });
   }
 };


### PR DESCRIPTION
This update allows passing any extra/custom configuration that a website might require for `Sentry.init()`.